### PR TITLE
feat: support self define date format such as: DD-MM-YYYY, MM-DD-YYYY…

### DIFF
--- a/examples/popup.js
+++ b/examples/popup.js
@@ -78,7 +78,7 @@ const Demo = React.createClass({
           onPickerChange={this.onPickerChange}
           onDismiss={this.onDismiss}
           onChange={this.onChange}
-          arrange={['days', 'years', 'months']}
+          format={['days', 'years', 'months']}
         >
           <button onClick={this.show}>{date && format(date) || 'open'}</button>
         </PopPicker>

--- a/examples/popup.js
+++ b/examples/popup.js
@@ -78,6 +78,7 @@ const Demo = React.createClass({
           onPickerChange={this.onPickerChange}
           onDismiss={this.onDismiss}
           onChange={this.onChange}
+          arrange={['days', 'years', 'months']}
         >
           <button onClick={this.show}>{date && format(date) || 'open'}</button>
         </PopPicker>

--- a/src/Popup.js
+++ b/src/Popup.js
@@ -90,6 +90,7 @@ const PopupDatePicker = React.createClass({
       <DatePicker
         date={this.state.pickerDate || props.date}
         mode={props.mode}
+        arrange={props.arrange}
         locale={props.locale}
         onDateChange={this.onPickerChange}
         {...dpProps}

--- a/src/Popup.js
+++ b/src/Popup.js
@@ -90,7 +90,7 @@ const PopupDatePicker = React.createClass({
       <DatePicker
         date={this.state.pickerDate || props.date}
         mode={props.mode}
-        arrange={props.arrange}
+        format={props.format}
         locale={props.locale}
         onDateChange={this.onPickerChange}
         {...dpProps}


### PR DESCRIPTION
目前在东南亚国家使用这套组件的时候，发现对本地化支持的不太好。参见[日期格式](https://docs.oracle.com/cd/E19683-01/816-3981/overview-46/index.html)。例如在泰国，我们希望的是月日年，而不是年月日，这和当地用户的使用习惯有较大差异。在查看Antd-mobile源码后发现，需要先改动rmc-date-picker，才能继续向ant-mobile提交代码，因此有了这个pull request.

![img](https://gw.alicdn.com/tfs/TB1VTu6MeH2gK0jSZJnXXaT1FXa-422-707.png)
